### PR TITLE
Added support for non-string field values in java

### DIFF
--- a/src/main/java/org/bigsolr/hadoop/SolrRecord.java
+++ b/src/main/java/org/bigsolr/hadoop/SolrRecord.java
@@ -120,7 +120,7 @@ public class SolrRecord implements Writable, Serializable {
     jsonStr.append("{");
     for(String fieldName : sd.getFieldNames()) {
       String escapedFieldName = StringEscapeUtils.escapeJava((String)fieldName);
-      String escapedFieldValue = StringEscapeUtils.escapeJava((String)sd.getFieldValue(fieldName));
+      String escapedFieldValue = StringEscapeUtils.escapeJava((String)sd.getFieldValue(fieldName).toString());
       jsonStr.append("\"" + escapedFieldName + "\":\"" + escapedFieldValue + "\",");
     }
 


### PR DESCRIPTION
For values in solr fields that are not type string, typecasting gives an error.